### PR TITLE
feat(download): detect verify the same as download

### DIFF
--- a/packages/bot/src/modules/utils/download.ts
+++ b/packages/bot/src/modules/utils/download.ts
@@ -22,6 +22,7 @@ export class DownloadModule extends ExtendedModule {
     'dowlaud',
     'dowlaid',
     'dowloand',
+    'verify',
   ]
 
   private DOWNLOAD_MESSAGE = `⚠⚠⚠ PLEASE READ THIS BEFORE CONTINUING IN THE ELECTRON DISCORD SERVER ⚠⚠⚠


### PR DESCRIPTION
`!verify` appears to also be related to the exploit.

If there's a better way to do this (without copy/pasting the entire file) let me know. This was the fastest way. :sweat_smile: 