### PR TITLE
feat(bot): Find roblox cheaters and warn them

### DIFF
--- a/packages/bot/src/modules/roblox-destructor/index.ts
+++ b/packages/bot/src/modules/roblox-destructor/index.ts
@@ -1,0 +1,17 @@
+import { client } from "../../lib/discord";
+
+const MSG = "**⚠️ WARNING**\nThis is not a Roblox server and we'll not attend you. If you're trying to build desktop apps with web technologies, please ignore this message."
+
+client.on("message", (msg) => {
+    const normalizedMsg = msg.toLowerCase().split(" ")
+    // When ALL are present, send a message
+    const isElectronWordIncluded = normalizedMsg.includes("electron")
+    const isInstallWordIncluded = normalizedMsg.includes("install")
+    if (isElectronWordIncluded && isInstallWordIncluded) {
+        msg.channel.send(MSG)
+    }
+    // Some people use the .download button to try to get a download link
+    if (msg.startsWith(".download")) {
+        msg.channel.send(MSG)
+    }
+})


### PR DESCRIPTION
# Todo
- [ ] The ideal thing would be to send the message only to that person, to not bother other people. But I don't know how to do it. It can be merged without this.

Oh, I just read that this isn't supported :/